### PR TITLE
Adding dockers layers to deploy easily. Front still missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8
+ENV PYTHONBUFFERED=1
+WORKDIR /code
+COPY Pipfile /code/
+COPY Pipfile.lock /code/
+RUN pip install pipenv 
+RUN pipenv sync
+RUN echo a
+COPY . /code/
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:latest
+    volumes:
+      - /home/sattisvar/data/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  migration:
+    build: .
+    image: app
+    command: bash -c "
+        pipenv run python unionGov/manage.py makemigrations
+        && pipenv run python unionGov/manage.py migrate 
+        && pipenv run python unionGov/manage.py loaddata --app gov default"
+    volumes:
+      - .:/code
+    links:
+      - db
+    depends_on: 
+      - db
+  web:
+    image: app
+    command: pipenv run python unionGov/manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+    links:
+      - db
+    depends_on:
+      - migration

--- a/unionGov/unionGov/settings.py
+++ b/unionGov/unionGov/settings.py
@@ -90,7 +90,9 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': os.environ['DB_NAME'],
         'USER': os.environ['DB_USER'],
-        'PASSWORD': os.environ['DB_PASSWORD']
+        'PASSWORD': os.environ['DB_PASSWORD'],
+        'HOST': os.environ['DB_HOST'],
+        'PORT': os.environ['DB_PORT'],
     }
 }
 


### PR DESCRIPTION
This development is to prepare the deployment via docker.

The docker compose contains the backend end, a postgresql server and the needed migrations to bootstrap.

Missing parts yet to come:
- Front  (sorry mario(c) this will be in another pull request)
- admin user for django (sorry luigi(c) this will be in another pull request)
- documentation about how to deploy (should be in this PR and will be added in coming commit)
